### PR TITLE
Handle nil values by restoring Swing defaults

### DIFF
--- a/src/main/clojure/retroact/swing.clj
+++ b/src/main/clojure/retroact/swing.clj
@@ -158,7 +158,7 @@
   (set-property-on-root-pane c (create/create-color color) #(.getForeground %) #(.setForeground %1 %2)))
 
 (defn set-columns [c ctx num-columns]
-  (.setColumns c num-columns))
+  (set-property c num-columns #(.getColumns %) #(.setColumns %1 %2)))
 
 (defn update-client-properties [c ctx properties]
   (let [{:keys [old-view attr]} ctx
@@ -198,7 +198,7 @@
   (.setToolTipText c tool-tip-text))
 
 (defn- set-scroll-bar [scroll-bar position]
-  (.setValue scroll-bar position))
+  (set-property scroll-bar position #(.getValue %) #(.setValue %1 %2)))
 
 (defn- set-vertical-scroll-bar [c ctx position]
   (let [scroll-bar (.getVerticalScrollBar c)]
@@ -209,10 +209,10 @@
     (set-scroll-bar scroll-bar position)))
 
 (defn- set-horizontal-scroll-bar-policy [c ctx policy]
-  (.setHorizontalScrollBarPolicy c policy))
+  (set-property c policy #(.getHorizontalScrollBarPolicy %) #(.setHorizontalScrollBarPolicy %1 %2)))
 
 (defn- set-vertical-scroll-bar-policy [c ctx policy]
-  (.setVerticalScrollBarPolicy c policy))
+  (set-property c policy #(.getVerticalScrollBarPolicy %) #(.setVerticalScrollBarPolicy %1 %2)))
 
 (defn- get-default-size [c]
   (let [preferred-size (.getPreferredSize c)
@@ -565,7 +565,8 @@
                                    (drop [drop-event] (handler (assoc local-ctx :app-val @app-ref) drop-event))))]))
 
 (defn- set-drag-enabled [c ctx drag-enabled]
-  (.setDragEnabled (get-scrollable-view c) drag-enabled))
+  (let [c (get-scrollable-view c)]
+    (set-property c drag-enabled #(.getDragEnabled %) #(.setDragEnabled %1 %2))))
 
 (defn- set-transfer-handler [c ctx transfer-handler]
   (.setTransferHandler (get-scrollable-view c) transfer-handler))

--- a/src/main/clojure/retroact/swing/borders.clj
+++ b/src/main/clojure/retroact/swing/borders.clj
@@ -1,6 +1,7 @@
 (ns retroact.swing.borders
   (:require [clojure.tools.logging :as log]
-            [retroact.swing.create-fns :refer [create-color create-font]])
+            [retroact.swing.create-fns :refer [create-color create-font]]
+            [retroact.toolkit.property-getters-setters :refer [set-property]])
   (:import (javax.swing BorderFactory Icon)
            (javax.swing.border Border EmptyBorder)))
 
@@ -56,8 +57,8 @@
     (vector? border) (set-border-fn c (create-border border))
     (instance? Border border) (set-border-fn c border)
     (nil? border) (do
-                    (log/warn "setting border to null, but it may be better to get the default border on a new component and use it")
-                    (set-border-fn c nil))
+                    (log/warn "setting border to nil; using component default")
+                    (set-property c nil #(.getBorder %) set-border-fn))
     :else (throw (Exception. (str "provided attr val is neither a Border nor a vector: " border)))))
 
 (defn set-border


### PR DESCRIPTION
## Summary
- Use default values for columns, scroll bars, scroll policies, drag-enabled, and borders when Swing setters receive `nil`
- Centralize property resetting with `set-property` to avoid invalid null assignments

## Testing
- `JAVA_TOOL_OPTIONS=-Djava.awt.headless=true ./gradlew test --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_689353af7f5083309279f6c5e9cf655f